### PR TITLE
Add support for specifying branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ GitHub Action for creating Cloudflare Pages deployments, using the new [Direct U
              projectName: YOUR_PROJECT_NAME
              directory: YOUR_ASSET_DIRECTORY
              gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+             environment: production
    ```
 
 1. Replace `YOUR_ACCOUNT_ID`, `YOUR_PROJECT_NAME` and `YOUR_ASSET_DIRECTORY` with the appropriate values to your Pages project.
@@ -52,3 +53,7 @@ To generate an API token:
 7. Select Continue to summary > Create Token.
 
 More information can be found on [our guide for making Direct Upload deployments with continous integration](https://developers.cloudflare.com/pages/how-to/use-direct-upload-with-continuous-integration/#use-github-actions).
+
+### Set environment
+Optionally, you can publish to a specific environment. By default, the environment will be set to `production` if run on
+the main branch of the repo; otherwise it is set to `preview`. 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ GitHub Action for creating Cloudflare Pages deployments, using the new [Direct U
              projectName: YOUR_PROJECT_NAME
              directory: YOUR_ASSET_DIRECTORY
              gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-             environment: production
    ```
 
 1. Replace `YOUR_ACCOUNT_ID`, `YOUR_PROJECT_NAME` and `YOUR_ASSET_DIRECTORY` with the appropriate values to your Pages project.
@@ -54,6 +53,9 @@ To generate an API token:
 
 More information can be found on [our guide for making Direct Upload deployments with continous integration](https://developers.cloudflare.com/pages/how-to/use-direct-upload-with-continuous-integration/#use-github-actions).
 
-### Set environment
-Optionally, you can publish to a specific environment. By default, the environment will be set to `production` if run on
-the main branch of the repo; otherwise it is set to `preview`. 
+### Specifying a branch
+The branch name is used by Cloudflare Pages to determine if the deployment is production or preview. Read more about
+[git branch build controls](https://developers.cloudflare.com/pages/platform/branch-build-controls/#branch-build-controls).
+
+If you are in a Git workspace, Wrangler will automatically pull the branch information for you. You can override this
+manually by adding the argument `branch: YOUR_BRANCH_NAME`.

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   gitHubToken:
     description: "GitHub Token"
     required: true
+  environment:
+    description: "Cloudflare environment"
+    required: false
 runs:
   using: "node16"
   main: "index.js"

--- a/action.yml
+++ b/action.yml
@@ -19,8 +19,8 @@ inputs:
   gitHubToken:
     description: "GitHub Token"
     required: true
-  environment:
-    description: "Cloudflare environment"
+  branch:
+    description: "The name of the branch you want to deploy to"
     required: false
 runs:
   using: "node16"

--- a/index.js
+++ b/index.js
@@ -16124,7 +16124,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName} --branch=${branch}"
+    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}" --branch="${branch}"
     `;
     const response = await (0, import_undici.fetch)(`https://api.cloudflare.com/client/v4/accounts/${accountId}/pages/projects/${projectName}/deployments`, { headers: { Authorization: `Bearer ${apiToken}` } });
     const {

--- a/index.js
+++ b/index.js
@@ -16124,7 +16124,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}" --env "${environment}"
+    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}" --binding ENV_NAME="${environment}"
     `;
     const response = await (0, import_undici.fetch)(`https://api.cloudflare.com/client/v4/accounts/${accountId}/pages/projects/${projectName}/deployments`, { headers: { Authorization: `Bearer ${apiToken}` } });
     const {

--- a/index.js
+++ b/index.js
@@ -16124,7 +16124,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}" --branch "${environment}"
+    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}"
     `;
     const response = await (0, import_undici.fetch)(`https://api.cloudflare.com/client/v4/accounts/${accountId}/pages/projects/${projectName}/deployments`, { headers: { Authorization: `Bearer ${apiToken}` } });
     const {

--- a/index.js
+++ b/index.js
@@ -16115,6 +16115,7 @@ try {
   const projectName = (0, import_core.getInput)("projectName", { required: true });
   const directory = (0, import_core.getInput)("directory", { required: true });
   const gitHubToken = (0, import_core.getInput)("gitHubToken", { required: true });
+  const environment = (0, import_core.getInput)("environment", { required: false });
   const octokit = (0, import_github.getOctokit)(gitHubToken);
   const createPagesDeployment = async () => {
     await esm_default`
@@ -16123,7 +16124,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}"
+    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName} --env ${environment}"
     `;
     const response = await (0, import_undici.fetch)(`https://api.cloudflare.com/client/v4/accounts/${accountId}/pages/projects/${projectName}/deployments`, { headers: { Authorization: `Bearer ${apiToken}` } });
     const {
@@ -16170,7 +16171,10 @@ try {
     (0, import_core.setOutput)("environment", pagesDeployment.environment);
     const url = new URL(pagesDeployment.url);
     const productionEnvironment = pagesDeployment.environment === "production";
-    const environmentName = productionEnvironment ? "Production" : `Preview (${url.host.split(".")[0]})`;
+    let environmentName = environment;
+    if (!environment) {
+      environmentName = productionEnvironment ? "Production" : `Preview (${url.host.split(".")[0]})`;
+    }
     if (gitHubDeployment) {
       await createGitHubDeploymentStatus({
         id: gitHubDeployment.id,

--- a/index.js
+++ b/index.js
@@ -16124,7 +16124,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}" --binding ENV_NAME="${environment}"
+    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}" --branch "${environment}"
     `;
     const response = await (0, import_undici.fetch)(`https://api.cloudflare.com/client/v4/accounts/${accountId}/pages/projects/${projectName}/deployments`, { headers: { Authorization: `Bearer ${apiToken}` } });
     const {

--- a/index.js
+++ b/index.js
@@ -16124,7 +16124,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName} --env ${environment}"
+    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}" --env "${environment}"
     `;
     const response = await (0, import_undici.fetch)(`https://api.cloudflare.com/client/v4/accounts/${accountId}/pages/projects/${projectName}/deployments`, { headers: { Authorization: `Bearer ${apiToken}` } });
     const {

--- a/index.js
+++ b/index.js
@@ -16115,7 +16115,7 @@ try {
   const projectName = (0, import_core.getInput)("projectName", { required: true });
   const directory = (0, import_core.getInput)("directory", { required: true });
   const gitHubToken = (0, import_core.getInput)("gitHubToken", { required: true });
-  const environment = (0, import_core.getInput)("environment", { required: false });
+  const branch = (0, import_core.getInput)("branch", { required: false });
   const octokit = (0, import_github.getOctokit)(gitHubToken);
   const createPagesDeployment = async () => {
     await esm_default`
@@ -16124,7 +16124,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}"
+    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName} --branch=${branch}"
     `;
     const response = await (0, import_undici.fetch)(`https://api.cloudflare.com/client/v4/accounts/${accountId}/pages/projects/${projectName}/deployments`, { headers: { Authorization: `Bearer ${apiToken}` } });
     const {
@@ -16171,10 +16171,7 @@ try {
     (0, import_core.setOutput)("environment", pagesDeployment.environment);
     const url = new URL(pagesDeployment.url);
     const productionEnvironment = pagesDeployment.environment === "production";
-    let environmentName = environment;
-    if (!environment) {
-      environmentName = productionEnvironment ? "Production" : `Preview (${url.host.split(".")[0]})`;
-    }
+    const environmentName = productionEnvironment ? "Production" : `Preview (${url.host.split(".")[0]})`;
     if (gitHubDeployment) {
       await createGitHubDeploymentStatus({
         id: gitHubDeployment.id,

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}" --binding ENV_NAME="${environment}"
+    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}" --branch "${environment}"
     `;
 
     const response = await fetch(

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName} --branch=${branch}"
+    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}" --branch="${branch}"
     `;
 
     const response = await fetch(

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ try {
   const projectName = getInput("projectName", { required: true });
   const directory = getInput("directory", { required: true });
   const gitHubToken = getInput("gitHubToken", { required: true });
+  const environment = getInput("environment", { required: false });
 
   const octokit = getOctokit(gitHubToken);
 
@@ -64,7 +65,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}"
+    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName} --env ${environment}"
     `;
 
     const response = await fetch(
@@ -129,9 +130,12 @@ try {
 
     const url = new URL(pagesDeployment.url);
     const productionEnvironment = pagesDeployment.environment === "production";
-    const environmentName = productionEnvironment
-      ? "Production"
-      : `Preview (${url.host.split(".")[0]})`;
+    let environmentName = environment
+    if (!environment) {
+      environmentName = productionEnvironment
+        ? "Production"
+        : `Preview (${url.host.split(".")[0]})`;
+    }
 
     if (gitHubDeployment) {
       await createGitHubDeploymentStatus({

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}" --branch "${environment}"
+    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}"
     `;
 
     const response = await fetch(
@@ -130,6 +130,9 @@ try {
 
     const url = new URL(pagesDeployment.url);
     const productionEnvironment = pagesDeployment.environment === "production";
+    // const environmentName = productionEnvironment
+    //   ? "Production"
+    //   : `Preview (${url.host.split(".")[0]})`;
     let environmentName = environment
     if (!environment) {
       environmentName = productionEnvironment

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}" --env "${environment}"
+    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}" --binding ENV_NAME="${environment}"
     `;
 
     const response = await fetch(

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ try {
   const projectName = getInput("projectName", { required: true });
   const directory = getInput("directory", { required: true });
   const gitHubToken = getInput("gitHubToken", { required: true });
-  const environment = getInput("environment", { required: false });
+  const branch = getInput("branch", { required: false });
 
   const octokit = getOctokit(gitHubToken);
 
@@ -65,7 +65,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}"
+    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName} --branch=${branch}"
     `;
 
     const response = await fetch(
@@ -130,15 +130,9 @@ try {
 
     const url = new URL(pagesDeployment.url);
     const productionEnvironment = pagesDeployment.environment === "production";
-    // const environmentName = productionEnvironment
-    //   ? "Production"
-    //   : `Preview (${url.host.split(".")[0]})`;
-    let environmentName = environment
-    if (!environment) {
-      environmentName = productionEnvironment
-        ? "Production"
-        : `Preview (${url.host.split(".")[0]})`;
-    }
+    const environmentName = productionEnvironment
+      ? "Production"
+      : `Preview (${url.host.split(".")[0]})`;
 
     if (gitHubDeployment) {
       await createGitHubDeploymentStatus({

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName} --env ${environment}"
+    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}" --env "${environment}"
     `;
 
     const response = await fetch(


### PR DESCRIPTION
As a user, I would like to provide my own logic to determine which deployments go to production and which go to preview. Adding support to specify the branch name gives me that flexibility since the branch name is used by Cloudflare Pages to determine if the deployment is production or preview.

In this PR, we have added the parameter `branch` that is passed directly to wranger2. Wrangler2 handles the situation when the [branch is empty](https://github.com/cloudflare/wrangler2/blob/73af915394db023c2a9565805cc6b53fd6b9ee49/packages/wrangler/src/pages/publish.tsx#L224), so no additional checks are needed.

Since this is an optional parameter, documentation is added as an aside. 

This closes https://github.com/cloudflare/pages-action/issues/11 https://github.com/cloudflare/pages-action/issues/12
